### PR TITLE
Hotfix/Change codecov.yml threshold value to 5%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,4 @@ coverage:
   precision: 2
   round: down
   range: "50...100"
+  threshold: 5%


### PR DESCRIPTION
Added threshold value of 5% to prevent failure from small code coverage change.