### PR TITLE
deleted useless buggy code causing test errors

### DIFF
--- a/lib/widget/map.dart
+++ b/lib/widget/map.dart
@@ -41,7 +41,6 @@ class _MapState extends State<Map> {
     _geolocator = Geolocator()..forceAndroidLocationManager;
     LocationOptions locationOptions = LocationOptions(
         accuracy: LocationAccuracy.bestForNavigation, distanceFilter: 1);
-    updateLocation();
     _positionStream =
         _geolocator.getPositionStream(locationOptions).listen((Position pos) {
       setState(() {
@@ -59,24 +58,6 @@ class _MapState extends State<Map> {
       _positionStream.cancel();
     }
     super.dispose();
-  }
-
-  void updateLocation() async {
-    try {
-      final GoogleMapController controller = await _completer.future;
-      Position position = await _geolocator
-          .getCurrentPosition(desiredAccuracy: LocationAccuracy.best)
-          .timeout(new Duration(seconds: 5));
-      setState(() {
-        _position = position;
-        _cameraPosition = CameraPosition(
-            target: LatLng(_position.latitude, _position.longitude),
-            zoom: constant.CAMERA_DEFAULT_ZOOM);
-      });
-      controller.animateCamera(CameraUpdate.newCameraPosition(_cameraPosition));
-    } catch (e) {
-      print('Error in updateLocation: ${e.toString()}');
-    }
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -96,7 +96,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.1"
+    version: "0.17.3+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   google_maps_flutter: 0.5.21+17
   geolocator: ^5.2.1
   flutter_typeahead: ^1.8.0
-  flutter_svg: 0.17.1
+  flutter_svg: ^0.17.3+1
   provider: ^4.0.2
   dio: ^3.0.9
   uuid: ^2.0.4


### PR DESCRIPTION
This is a hotfix to the weird test build errors we were getting from travis CI. It seemed like what was causing the errors was of no value anyways. If you notice, the updateLocation() was only for initialization of getting user's location, but this is already being done by the _positionStream. I think we can safely delete this, and it is best to do so.