### PR TITLE
Bug #94 : GoToPage broken

### DIFF
--- a/lib/view/goto_page_new.dart
+++ b/lib/view/goto_page_new.dart
@@ -77,7 +77,7 @@ class _GotoPageState extends State<GotoPage> {
                                 delegate: PositionedFloatingSearchBar(
                                     coordinate: (Future<Coordinate> val) {
                                       setState(() async {
-                                        _searchedStart = await val;
+                                        _searchedDestination = await val;
                                   });
                                 }),
                               );


### PR DESCRIPTION
This PR closes #94 where the starting position and destination selection menu was broken. 