### PR TITLE
Bug/Reset direction duration

### DIFF
--- a/lib/provider/direction_notifier.dart
+++ b/lib/provider/direction_notifier.dart
@@ -181,5 +181,6 @@ class DirectionNotifier extends ChangeNotifier {
     apiCallCounter = 0;
     totalDuration = 0;
     totalDistance = 0;
+    duration = "0 min";
   }
 }

--- a/lib/widget/map.dart
+++ b/lib/widget/map.dart
@@ -89,6 +89,7 @@ class _MapState extends State<Map> {
           myLocationButtonEnabled: false,
           compassEnabled: false,
           indoorViewEnabled: false,
+          mapToolbarEnabled: false,
           scrollGesturesEnabled: true,
           rotateGesturesEnabled: true,
           tiltGesturesEnabled: true,


### PR DESCRIPTION
This PR closes bug #141 , where the duration does not reset immediately after selecting indoor only directions once outdoor/combined directions have been retrieved.