### PR TITLE
hotfix : Now clears all directions, lines and markers after returning…

### DIFF
--- a/lib/widget/direction_panel.dart
+++ b/lib/widget/direction_panel.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:sliding_up_panel/sliding_up_panel.dart';
 
 class DirectionPanel extends StatefulWidget {
-  final Function(bool) removeDirectionPolyline;
+  final VoidCallback removeDirectionPolyline;
 
   DirectionPanel({this.removeDirectionPolyline});
 
@@ -56,7 +56,7 @@ class DirectionPanelState extends State<DirectionPanel> {
                                   directionNotifier
                                       .setShowDirectionPanel(false),
                                   directionNotifier.clearAll(),
-                                  widget.removeDirectionPolyline(true)
+                                  widget.removeDirectionPolyline()
                                 })
                       ],
                     ),

--- a/lib/widget/map.dart
+++ b/lib/widget/map.dart
@@ -186,6 +186,7 @@ class _MapState extends State<Map> {
           SearchBar(coordinate: (Future<Coordinate> coordinate) async {
             setState(() {
               directionNotifier.setShowDirectionPanel(false);
+              clearAllDirections();
               mapMarkers
                   .removeWhere((marker) => marker.markerId.value == 'pop-up');
             });
@@ -229,18 +230,23 @@ class _MapState extends State<Map> {
             },
           ),
           DirectionPanel(
-              removeDirectionPolyline: (bool removePolyline) => {
-                    direction.clear(),
-                    shortestPath = {},
-                    markerHelper.removeStartEndMarker(),
-                    mapMarkers.removeWhere((marker) =>
-                        marker.markerId.value == 'start' ||
-                        marker.markerId.value == 'end' ||
-                        marker.markerId.value == 'destination'),
-                  }),
+              removeDirectionPolyline: clearAllDirections),
         ],
       ),
     );
+  }
+
+  /*
+  Call this method to remove all direction related polyline and markers
+   */
+  void clearAllDirections() {
+    direction.clear();
+    shortestPath = {};
+    markerHelper.removeStartEndMarker();
+    mapMarkers.removeWhere((marker) =>
+    marker.markerId.value == 'start' ||
+    marker.markerId.value == 'end' ||
+    marker.markerId.value == 'destination');
   }
 
   /*


### PR DESCRIPTION
The PR addresses a usability issue for when the user retrieves step-by-step directions and then searches for a location via the main search bar. The fix will now remove all direction related lines and markers to improve usability and overall user experience.